### PR TITLE
Do inference tiles by tiles, algo annotations and upgrade Stardist version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM cytomine/software-python3-base:v2.2.0
 
 # -----------------------------------------------------------------------------
 # Install Stardist and tensorflow
-RUN pip install tensorflow==2.2.0
-RUN pip install stardist==0.6.0
+RUN pip install tensorflow==2.8.0
+RUN pip install stardist==0.8.0
 RUN mkdir -p /models && \
     cd /models && \
     mkdir -p 2D_versatile_HE

--- a/run.py
+++ b/run.py
@@ -105,10 +105,12 @@ def main(argv):
                 for x in range(0,len(X)):
                     print("------------------- Processing ROI file %d: %s" %(x,roi_tif_filename))
                     img = normalize(X[x], conn.parameters.stardist_norm_perc_low, conn.parameters.stardist_norm_perc_high, axis=axis_norm)
+                    n_tiles = model._guess_n_tiles(img)
                     #Stardist model prediction with thresholds
                     labels, details = model.predict_instances(img,
                                                               prob_thresh=conn.parameters.stardist_prob_t,
-                                                              nms_thresh=conn.parameters.stardist_nms_t)
+                                                              nms_thresh=conn.parameters.stardist_nms_t,
+                                                              n_tiles=n_tiles)
                     print("Number of detected polygons: %d" %len(details['coord']))
                     cytomine_annotations = AnnotationCollection()
                     #Go over detections in this ROI, convert and upload to Cytomine

--- a/run.py
+++ b/run.py
@@ -27,7 +27,7 @@ from csbdeep.utils import Path, normalize
 from stardist import random_label_cmap
 from stardist.models import StarDist2D
 from cytomine import cytomine, models, CytomineJob
-from cytomine.models import Annotation, AnnotationTerm, AnnotationCollection, ImageInstanceCollection, Job
+from cytomine.models import Annotation, AnnotationTerm, AnnotationCollection, ImageInstanceCollection, Job, User
 from PIL import Image
 import argparse
 import json
@@ -62,11 +62,13 @@ def main(argv):
         for id_image in conn.monitor(list_imgs, prefix="Running detection on image", period=0.1):
             #Dump ROI annotations in img from Cytomine server to local images
             #conn.job.update(status=Job.RUNNING, progress=0, statusComment="Fetching ROI annotations...")
-            roi_annotations = AnnotationCollection()
-            roi_annotations.project = conn.parameters.cytomine_id_project
-            roi_annotations.term = conn.parameters.cytomine_id_roi_term
-            roi_annotations.image = id_image #conn.parameters.cytomine_id_image
-            roi_annotations.showWKT = True
+            roi_annotations = AnnotationCollection(
+                terms=[conn.parameters.cytomine_id_roi_term],
+                project=conn.parameters.cytomine_id_project,
+                image=id_image, #conn.parameters.cytomine_id_image
+                showWKT = True,
+                includeAlgo=True, 
+            )
             roi_annotations.fetch()
             print(roi_annotations)
             #Go over ROI in this image
@@ -85,7 +87,8 @@ def main(argv):
                 roi_path=os.path.join(working_path,str(roi_annotations.project)+'/'+str(roi_annotations.image)+'/'+str(roi.id))
                 roi_png_filename=os.path.join(roi_path+'/'+str(roi.id)+'.png')
                 print("roi_png_filename: %s" %roi_png_filename)
-                roi.dump(dest_pattern=roi_png_filename,mask=True,alpha=True)
+                is_algo = User().fetch(roi.user).algo
+                roi.dump(dest_pattern=roi_png_filename,mask=True,alpha=not is_algo)
                 #roi.dump(dest_pattern=os.path.join(roi_path,"{id}.png"), mask=True, alpha=True)
             
                 #Stardist works with TIFF images without alpha channel, flattening PNG alpha mask to TIFF RGB


### PR DESCRIPTION
- Do inference tiles by tiles to improve RAM performance and avoid to go out of RAM on big ROI.
- Accept algo annotations.
- Upgrade Tensorflow to 2.8.0 and Stardist to 0.8.0.